### PR TITLE
5534 - ET - fixed overflow, max value is 90 days

### DIFF
--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -99,7 +99,7 @@ function socketAuthorize(options, io, coreModule, onConnection) {
         if (context.data.origin) {
             invalidateAllSocketsAtThisOriginWhichAreNotRelatedToUser(currentSocket.server.sockets.sockets, context.data.origin, currentSocket.userId);
         }
-        
+
         const newToken = refreshToken(decodedToken, context.data.token);
         // When the socket is created, the origin is defined so that it can be determined
         // which sockets are connected to the same origin

--- a/lib/user-session.service.js
+++ b/lib/user-session.service.js
@@ -443,6 +443,17 @@ function _scheduleAutoLogout(userSession) {
 
 async function logout(origin, reason) {
     const userSession = service.getLocalUserSession(origin);
+    if (!userSession) {
+        // this handles the very rare edge case where the logout is received on the socket while
+        // the client is in the process of getting authorized (maybe after a loss of connection) on a server that
+        // was never connected (local session is about to be created asynchronously).
+        // The open door for hacking is very very tight - Potentially other servers will not get logged out
+        // until zerv purges the inactive sessions by itself.
+        // So this could be optimized, for ie:
+        // Make more secure in the future by looking in the shared cache in a cluster session exists at the origin and notify all servers
+        // to make sure all servers log out (resource release) and related active tokens are revoked properly right away.
+        return null;
+    }
     await service._logoutLocally(userSession, reason);
     if (zerv.publish) {
         zerv.notifyCreation(

--- a/lib/user-session.service.js
+++ b/lib/user-session.service.js
@@ -277,14 +277,11 @@ function getLocalUserSession(origin) {
 }
 
 
-// DO NOT REMOVE NOTES:
-
+// DO NOT REMOVE NOTES YET:
 // user goes to credentials
 // ui create the origin based on refreshed token
-
 // if it goes to credentials page again, the origin will not change
 // if it comes from SSO (dash), the origin will not change
-
 // the session is created and should removed on logout
 
 // Constraint

--- a/lib/user-session.service.js
+++ b/lib/user-session.service.js
@@ -5,11 +5,13 @@ const assert = require('assert');
 const zlog = require('zimit-zlog');
 const tokenBlacklistService = require('./token-blacklist.service');
 const cacheService = require('./cache.service');
+const utils = require('./utils');
 
 const logger = zlog.getLogger('zerv/core/userSession');
 
 const zervServerId = UUID.v4();
 const REDIS_SESSION_PREFIX = 'SESSION_';
+const DEFAULT_MAX_TIMEOUT_IN_MINS = 90 * 24 *60;
 
 let localUserSessions = {}, localUserSessionDestroyListeners = {}, tenantMaximumActiveSessionTimeouts = {};
 let _clearOldUserSessionsIntervalHandle;
@@ -357,7 +359,7 @@ async function createLocalUserSession(socket) {
 
 function _destroyLocalUserSession(userSession, reason) {
     userSession.active = false;
-    clearTimeout(userSession.timeout);
+    utils.clearLongTimeout(userSession.timeout);
     userSession.timeout = null;
     delete localUserSessions[userSession.origin];
 
@@ -423,7 +425,7 @@ async function _getClusterUserSession(localUserSession) {
 }
 
 function _scheduleAutoLogout(userSession) {
-    const remainingTime = userSession. getRemainingTimeInSecs();
+    const remainingTime = userSession. getRemainingTimeInSecs() / 60;
     const maximumSessionTime = userSession.getMaximumSessionTime();
 
     if (remainingTime <= 0) {
@@ -432,10 +434,10 @@ function _scheduleAutoLogout(userSession) {
         service.logout(userSession.origin, 'session_timeout');
         return null;
     }
-    logger.info('%s is set to expire in %s min(s) on %s', userSession, (remainingTime/60).toFixed(1), moment(maximumSessionTime));
-    return setTimeout(
+    logger.info('%s is set to expire in %s min(s) on %s', userSession, remainingTime.toFixed(1), moment(maximumSessionTime));
+    return utils.setLongTimeout(
         () => service.logout(userSession.origin, 'session_timeout'),
-        remainingTime * 1000
+        remainingTime
     );
 }
 
@@ -488,9 +490,11 @@ function setTenantMaximumActiveSessionTimeout(tenantId, valueInMins) {
 }
 
 function getTenantMaximumActiveSessionTimeoutInMins(tenantId) {
-    // in minutes
-    const value = tenantMaximumActiveSessionTimeouts[tenantId];
-    return _.isNil(value) || value < 1 ? process.env.ZERV_MAX_ACTIVE_SESSION_TIMEOUT_IN_MINS || 60 * 12: value;
+    const valueInMins = tenantMaximumActiveSessionTimeouts[tenantId];
+    if (_.isNil(valueInMins) || valueInMins < 1 || valueInMins > DEFAULT_MAX_TIMEOUT_IN_MINS) {
+        return DEFAULT_MAX_TIMEOUT_IN_MINS;
+    }
+    return valueInMins;
 }
 
 async function findClusterUserSession(origin) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,62 @@
+const _ = require('lodash');
+const service = {
+    setLongTimeout,
+    clearLongTimeout,
+    _setTimeout
+};
+
+module.exports = service;
+
+// Node timeout cannot handle more than about 24.9 days
+// internally uses a signed 32 bit
+
+const MAX_TIMEOUT_DAYS = 20;
+
+class Timeout {
+    constructor(fn, valueInMins) {
+        this.fn = fn;
+        this.remainingDays = Math.trunc(valueInMins / (60*24));
+        if (this.remainingDays > MAX_TIMEOUT_DAYS) {
+            this.remainingMins = valueInMins-(this.remainingDays * 24 * 60);
+        } else {
+            this.remainingMins = valueInMins;
+            this.remainingDays = 0;
+        }
+        this._setTimeout();
+    }
+    _setTimeout() {
+        if (this.remainingDays <= MAX_TIMEOUT_DAYS) {
+            const remaining = (this.remainingDays * 24 * 60) + this.remainingMins;
+            if (remaining=== 0) {
+                this.fn();
+            } else {
+                this.timeout = service._setTimeout(this.fn, remaining * 60 * 1000);
+            }
+        } else {
+            // reduced the number of times to timeout.
+            this.timeout = service._setTimeout(() => {
+                this.remainingDays -= MAX_TIMEOUT_DAYS;
+                this.timeout = this._setTimeout();
+            }, MAX_TIMEOUT_DAYS * 24 * 60 * 60 * 1000);
+        }
+    }
+    destroy() {
+        clearTimeout(this.timeout);
+    }
+}
+function setLongTimeout(fn, value, options = {}) {
+    if (_.isNumber(options.max) && value > options.max) {
+        value = options.max;
+    }
+    return new Timeout(fn, value);
+}
+
+function clearLongTimeout(timeout) {
+    if (!_.isNil(timeout)) {
+        timeout.destroy();
+    }
+}
+
+function _setTimeout(fn, value) {
+    return setTimeout(fn, value);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerv-core",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Zerv core module provides authentication of socket.io connections using Auth Code and token refresh on top of JWT",
   "main": "lib/zerv-core.js",
   "keywords": [
@@ -11,8 +11,8 @@
     "application server"
   ],
   "author": {
-    "name": "Emmanuel Telmon & Others at Zimit",
-    "email": "etelmon@gmail.com"
+    "name": "Zimit Team",
+    "email": "etelmon@zimit.io"
   },
   "repository": {
     "type": "git",

--- a/test/user-session.service.spec.js
+++ b/test/user-session.service.spec.js
@@ -10,6 +10,7 @@ const cacheService = require('../lib/cache.service');
 let io;
 
 describe('user-session.service', () => {
+    
     let socketForUser01, socket2ForUser01, socketForUser02, socketForUser03;
     let now;
     let serverInstanceId;

--- a/test/user-session.service.spec.js
+++ b/test/user-session.service.spec.js
@@ -182,7 +182,7 @@ describe('user-session.service', () => {
                     active: true,
                     firstName: 'Luke',
                     lastName: 'John',
-                    maxActiveDuration: 720,
+                    maxActiveDuration: 129600,
                     clusterCreation: null,
                     clusterUserSessionId: null,
                     connections: 1
@@ -211,7 +211,7 @@ describe('user-session.service', () => {
                     active: true,
                     firstName: 'Luke',
                     lastName: 'John',
-                    maxActiveDuration: 720,
+                    maxActiveDuration: 129600,
                     clusterCreation: now,
                     clusterUserSessionId: 'aUuid',
                     connections: 1
@@ -219,8 +219,8 @@ describe('user-session.service', () => {
             );
             expect(cacheService.cacheData).toHaveBeenCalledWith(
                 'browserId01', 
-                {"clusterUserSessionId":"aUuid","userId":"user01","origin":"browserId01","tenantId":"corpPlus","clusterCreation":now,"firstName":"Luke","lastName":"John","maxActiveDuration":720},
-                { prefix: 'SESSION_', expirationInMins: 720 }
+                {"clusterUserSessionId":"aUuid","userId":"user01","origin":"browserId01","tenantId":"corpPlus","clusterCreation":now,"firstName":"Luke","lastName":"John","maxActiveDuration":129600},
+                { prefix: 'SESSION_', expirationInMins: 129600 }
             );
         });
 
@@ -234,7 +234,7 @@ describe('user-session.service', () => {
                 clusterCreation,
                 firstName: "Luke",
                 lastName: "John",
-                maxActiveDuration: 720
+                maxActiveDuration: 129600
             });
             service.init(zerv, io, maxInactiveTimeInMinsForInactiveSession);
             io.sockets.sockets = [socketForUser01];
@@ -254,7 +254,7 @@ describe('user-session.service', () => {
                     active: true,
                     firstName: 'Luke',
                     lastName: 'John',
-                    maxActiveDuration: 720,
+                    maxActiveDuration: 129600,
                     clusterCreation,
                     clusterUserSessionId: "existingUuid",
                     connections: 1
@@ -323,7 +323,7 @@ describe('user-session.service', () => {
                     active: false,
                     firstName: 'Luke',
                     lastName: 'John',
-                    maxActiveDuration: 720,
+                    maxActiveDuration: 129600,
                     clusterCreation: null,
                     clusterUserSessionId: null,
                     connections: 0
@@ -408,7 +408,6 @@ describe('user-session.service', () => {
             expect(service._scheduleAutoLogout).toHaveBeenCalledWith(localUser01Session);
             expect(localUser01Session.getRemainingTimeInSecs()).toEqual(0);
             expect(service.logout).toHaveBeenCalledWith(localUser01Session.origin, 'session_timeout');
-
         });
 
     })
@@ -624,13 +623,18 @@ describe('user-session.service', () => {
             expect(service.getTenantMaximumActiveSessionTimeoutInMins('prudentTenantId')).toEqual(60);
         });
 
-        it('should be a default value for invalid value', () => {
+        it('should be a default max value for invalid value', () => {
             service.setTenantMaximumActiveSessionTimeout('aTenant', -5);
-            expect(service.getTenantMaximumActiveSessionTimeoutInMins('aTenant')).toEqual(720);
+            expect(service.getTenantMaximumActiveSessionTimeoutInMins('aTenant')).toEqual(129600);
+        });
+
+        it('should user default max value when value is too high', () => {
+            service.setTenantMaximumActiveSessionTimeout('aTenant', 500000);
+            expect(service.getTenantMaximumActiveSessionTimeoutInMins('aTenant')).toEqual(129600);
         });
         
-        it('should be a default value for inexisting tenant', () => {
-            expect(service.getTenantMaximumActiveSessionTimeoutInMins('carelessTenantId')).toEqual(720);
+        it('should be a default max value for inexisting tenant', () => {
+            expect(service.getTenantMaximumActiveSessionTimeoutInMins('carelessTenantId')).toEqual(129600);
         });
     });
 

--- a/test/user-session.service.spec.js
+++ b/test/user-session.service.spec.js
@@ -615,6 +615,14 @@ describe('user-session.service', () => {
             expect(zervWithSyncModule.notifyCreation).not.toHaveBeenCalled();
         });
 
+        it('should not release any session if the session does not exist for provided origin', async () => {
+            service.init(zervWithSyncModule, io, maxInactiveTimeInMinsForInactiveSession);
+            service.getLocalUserSession.and.returnValue(null);
+            await service.logout('unknownSessionOnLocalServer', 'logout_test');
+            expect(service._logoutLocally).not.toHaveBeenCalled();
+            expect(zervWithSyncModule.notifyCreation).not.toHaveBeenCalled();
+        });
+
     });
 
     describe('tenantMaximumActiveSessionTimeout value', () => {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -25,7 +25,13 @@ describe('utils', () => {
             jasmine.clock().tick(30 * 60 * 1000);
             expect(fn).toHaveBeenCalledTimes(1);   
             expect(utils._setTimeout).toHaveBeenCalledWith(fn, 1800000);
+        });
 
+        it('should timeout at the max value instead', async () => {
+            utils.setLongTimeout(fn, 100, {max: 30});
+            jasmine.clock().tick(30 * 60 * 1000);
+            expect(fn).toHaveBeenCalledTimes(1);   
+            expect(utils._setTimeout).toHaveBeenCalledWith(fn, 1800000);
         });
 
         it('should not timeout', async () => {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,119 @@
+'use strict';
+const moment = require('moment');
+const _ = require('lodash');
+const utils = require('../lib/utils');
+
+describe('utils', () => {
+    let fn;
+    
+    beforeEach(() => {
+        const now = moment('Feb 6 2020 05:06:07', 'MMM DD YYYY hh:mm:ss').toDate();
+        jasmine.clock().install();
+        jasmine.clock().mockDate(now);
+        fn = jasmine.createSpy('fn');
+        spyOn(utils, '_setTimeout').and.callThrough();
+    });
+
+    afterEach(() => {
+        jasmine.clock().uninstall();
+    });
+
+    describe('setLongTimeout', () => {
+
+        it('should timeout at once', async () => {
+            utils.setLongTimeout(fn, 30);
+            jasmine.clock().tick(30 * 60 * 1000);
+            expect(fn).toHaveBeenCalledTimes(1);   
+            expect(utils._setTimeout).toHaveBeenCalledWith(fn, 1800000);
+
+        });
+
+        it('should not timeout', async () => {
+            utils.setLongTimeout(fn, 30);
+            jasmine.clock().tick(15 * 60 * 1000);
+            expect(fn).not.toHaveBeenCalled();           
+        });
+
+        it('should timeout in 1 cycle', async () => {
+            const days = 20;
+            const timeout = utils.setLongTimeout(fn, days * 24 * 60);
+            expect(timeout.remainingDays).toEqual(0);
+            expect(timeout.remainingMins).toEqual(28800);
+            jasmine.clock().tick(20 * 24 * 60 * 60 * 1000);
+            expect(fn).toHaveBeenCalledTimes(1);  
+            expect(utils._setTimeout).toHaveBeenCalledTimes(1);         
+            expect(utils._setTimeout).toHaveBeenCalledWith(fn, 1728000000);
+        });
+
+        it('should timeout in 2 cycles', async () => {
+            const days = 21;
+            const timeout = utils.setLongTimeout(fn, days * 24 * 60);
+            expect(timeout.remainingDays).toEqual(21);
+            expect(timeout.remainingMins).toEqual(0);
+            jasmine.clock().tick(21 * 24 * 60 * 60 * 1000);
+            expect(fn).toHaveBeenCalledTimes(1);           
+            expect(utils._setTimeout).toHaveBeenCalledTimes(2);    
+            expect(utils._setTimeout.calls.argsFor(0)).toEqual([jasmine.any(Function), 1728000000]);
+            expect(utils._setTimeout.calls.argsFor(1)).toEqual([fn, 86400000 ]);
+        });
+
+        it('should timeout in 3 cycles', async () => {
+            const days = 41;
+            const timeout = utils.setLongTimeout(fn, days * 24 * 60);
+            expect(timeout.remainingDays).toEqual(41);
+            expect(timeout.remainingMins).toEqual(0);
+            jasmine.clock().tick(41 * 24 * 60 * 60 * 1000);
+            expect(fn).toHaveBeenCalledTimes(1);     
+            expect(utils._setTimeout).toHaveBeenCalledTimes(3);       
+            expect(utils._setTimeout.calls.argsFor(0)).toEqual([jasmine.any(Function), 1728000000]);
+            expect(utils._setTimeout.calls.argsFor(1)).toEqual([jasmine.any(Function), 1728000000]);
+            expect(utils._setTimeout.calls.argsFor(2)).toEqual([fn, 86400000 ]);
+        });
+
+        it('should use the maximum timeout', async () => {
+            const days = 1000000;
+            const timeout = utils.setLongTimeout(fn, days * 24 * 60, {max: 41 * 24 * 60});
+            jasmine.clock().tick(41 * 24 * 60 * 60 * 1000);
+            expect(fn).toHaveBeenCalledTimes(1);     
+            expect(utils._setTimeout).toHaveBeenCalledTimes(3);       
+            expect(utils._setTimeout.calls.argsFor(0)).toEqual([jasmine.any(Function), 1728000000]);
+            expect(utils._setTimeout.calls.argsFor(1)).toEqual([jasmine.any(Function), 1728000000]);
+            expect(utils._setTimeout.calls.argsFor(2)).toEqual([fn, 86400000 ]);
+        });
+    });
+
+    describe('clearLongTimeout', () => {
+
+        it('should clear timeout', async () => {
+            const timeout = utils.setLongTimeout(fn, 30);
+            utils.clearLongTimeout(timeout);
+            jasmine.clock().tick(30 * 60 * 1000);
+            expect(fn).toHaveBeenCalledTimes(0);   
+        });
+
+        it('should clear timeout during 2nd cycle', async () => {
+            const days = 21;
+            const timeout = utils.setLongTimeout(fn, days * 24 * 60);
+            jasmine.clock().tick(20 * 24 * 60 * 60 * 1000);
+            utils.clearLongTimeout(timeout);
+            expect(fn).not.toHaveBeenCalled();           
+            expect(utils._setTimeout).toHaveBeenCalledTimes(2);    
+            expect(utils._setTimeout.calls.argsFor(0)).toEqual([jasmine.any(Function), 1728000000]);
+            expect(utils._setTimeout.calls.argsFor(1)).toEqual([fn, 86400000 ]);
+        });
+
+        it('should clear timeout during 2nd cycle preventing from running a 3rd cycle', async () => {
+            const days = 41;
+            const timeout = utils.setLongTimeout(fn, days * 24 * 60);
+            expect(timeout.remainingDays).toEqual(41);
+            expect(timeout.remainingMins).toEqual(0);
+            jasmine.clock().tick(39 * 24 * 60 * 60 * 1000);
+            utils.clearLongTimeout(timeout);
+            expect(fn).not.toHaveBeenCalled();           
+            expect(utils._setTimeout).toHaveBeenCalledTimes(2);       
+            expect(utils._setTimeout.calls.argsFor(0)).toEqual([jasmine.any(Function), 1728000000]);
+            expect(utils._setTimeout.calls.argsFor(1)).toEqual([jasmine.any(Function), 1728000000]);
+        });
+    });
+
+});


### PR DESCRIPTION
User sessions cannot last longer than 90 days (hard coded)

<h3 id="steps-to-reproduce">1. Steps to Reproduce</h3>

**Test library**
Make sure the automatic tests pass.

`npm test`

**Test for regression your application login and logout functionalities**
The test cases are in the app pr 5534. 
This is the idea:
- log in your app and open many tabs
- Log out
- All tabs should be logged out
- log in your app and open many tabs
- Wait for your session timeout
- All tabs should be logged out

<h3 id="performance-considerations">2. Performance Considerations</h3>
No performance impact besides adding minimum timeout triggering logic.

<h3 id="additional-notes">Additional Notes</h3>

Zerv Sync and security libs  are also impacted due to new Zerv core lib version.
