### PR TITLE
6718 - ET - Fix socket buffer size preventing from emitting large objects

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -113,7 +113,26 @@
 			"sourceMaps": false,
 			"outDir": null
 		},
-
+		{
+			"name": "debug zerv-core entry point",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/node_modules/jasmine/bin/jasmine.js",
+			"stopOnEntry": false,
+			"args": ["test/zerv-core.spec.js"],
+			"cwd": "${workspaceRoot}",
+			"preLaunchTask": null,
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"externalConsole": false,
+			"sourceMaps": false,
+			"outDir": null
+		},
 		{
 			"name": "debug zerv user session",
 			"type": "node",

--- a/lib/authorize/socket-authorize.js
+++ b/lib/authorize/socket-authorize.js
@@ -140,9 +140,9 @@ function socketAuthorize(authOptions, io, coreModule) {
                 await checkForValidUserSession(connData.origin);
                 // No need to refresh the token, it is just a new connection from a network loss or an additional browser tab
                 // ..................................
-                // To dig in: if the token is close to get refreshed, a refreshed token could be sent instead;
-                // However, If many tabs compete to reconnect at the same time\,
-                // this could lead to revoked tokens and a tab triggering a full logout
+                // To dig in: if the token is close to get refreshed, a refreshed token could be sent back instead;
+                // However, If many tabs compete to reconnect at the same time,
+                // this could lead to using revoked tokens and a tab triggering a full logout
                 // ..................................
                 oldTokenExp = null;
                 newToken = oldToken;

--- a/lib/zerv-core.js
+++ b/lib/zerv-core.js
@@ -117,7 +117,7 @@ function socketServe(server, options) {
     options.tokenRefreshIntervalInMins = options.tokenRefreshIntervalInMins ? Number(options.tokenRefreshIntervalInMins) : 5;
 
     // socketio 2.X used to be 100mgb (default)
-    const maxHttpBufferSize = parseInt(options.maxHttpBufferSize) || parseInt(process.env.ZERV_SOCKET_MAX_HTTP_BUFFER_SIZE) || (100 * 1000 * 1024);
+    const maxHttpBufferSize = parseInt(options.maxHttpBufferSize) || (100 * 1000 * 1024);
     const io = new SocketIoServer({
         maxHttpBufferSize
     });

--- a/lib/zerv-core.js
+++ b/lib/zerv-core.js
@@ -103,6 +103,7 @@ async function shutdown(delayBeforeShuttingdown = 5, exitDelay = 5) {
  *                                                               if a valid token is used, the local session will be recreated
  * @param {Function} options.claim this function receives a user object and generates the content of the token payload
  * @param {String} options.secret this is the secret phrase to sign and verify a token
+ * @param {Number} options.maxHttpBufferSize how many bytes or characters a message can be, before closing the session (to avoid DoS).
  * @param {Function} options.refresh this function receives a payload object and generates the token. By default a function is provided which uses JWT sign.
  * @param {Function} options.getTenantId this function receives a payload object and uses its data (such as user Id) to figure out the tenantId. TenantId should never be stored in a token.
  *
@@ -115,7 +116,11 @@ function socketServe(server, options) {
 
     options.tokenRefreshIntervalInMins = options.tokenRefreshIntervalInMins ? Number(options.tokenRefreshIntervalInMins) : 5;
 
-    const io = new SocketIoServer();
+    // socketio 2.X used to be 100mgb (default)
+    const maxHttpBufferSize = parseInt(options.maxHttpBufferSize) || parseInt(process.env.ZERV_SOCKET_MAX_HTTP_BUFFER_SIZE) || (100 * 1000 * 1024);
+    const io = new SocketIoServer({
+        maxHttpBufferSize
+    });
     io.sockets
       .on('connection', socketAuthorize(options, io, coreModule));
     io.attach(server);

--- a/test/zerv-core.spec.js
+++ b/test/zerv-core.spec.js
@@ -1,0 +1,35 @@
+const _ = require('lodash');
+const express = require('express');
+const http = require('http');
+const zerv = require('../lib/zerv-core');
+
+describe('zerv-core', () => {
+    let server, options;
+    beforeEach(() => {
+        const app = express();
+        server = http.createServer(app);
+
+        options = {
+            claim: _.noop,
+            findUserByCredentials: _.noop
+        };
+    });
+
+    describe('socketServe', () => {
+
+        it('should use maxHttpBufferSize default value', () => {
+            const io = zerv.socketServe(server, options);
+            expect(io.opts).toEqual({
+                maxHttpBufferSize: 102400000
+            });
+        });
+
+        it('should set the maxHttpBufferSize value', () => {
+            options.maxHttpBufferSize = 2048;
+            const io = zerv.socketServe(server, options);
+            expect(io.opts).toEqual({
+                maxHttpBufferSize: 2048
+            });
+        });
+    });
+});


### PR DESCRIPTION
Jira Task: https://zimitio.atlassian.net/browse/ZWEB-6718

This PR fixes an issue preventing large objects to be sent over the socket.
The issue was introduced by the socketio upgrade in https://github.com/z-open/zerv-core/pull/17.

Set the default of the socket http buffer to 100 mgb as it was before with socketio 2.3.0.


Run:
npm test

Performance Considerations
None.

Sections of the Application Affected
Look up application pr to QA.